### PR TITLE
Filters

### DIFF
--- a/src/containers/Filters/Filters.js
+++ b/src/containers/Filters/Filters.js
@@ -2,37 +2,78 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-export const Filters = (props) => {
-  const handleChange = event => {
-    const { name, value } = event.target;
-  };
+export const Filters = ({ events }) => {
+  const [eventType, updateType] = useState('');
+  const [month, updateMonth] = useState('');
+  const [state, updateState] = useState('');
 
-  return (
-    <div className="Filters">
-      <h3 className="filters-title">FILTER EVENTS</h3>
-      <select
-        name="event_type"
-        value={''}
-        onChange={handleChange}
-      >
-        <option value="">Event Type</option>
-      </select>
-      <select
-        name="start_date"
-        value={''}
-        onChange={handleChange}
-      >
-        <option value="Date">Date</option>
-      </select>
-      <select
-        name="state"
-        value={''}
-        onChange={handleChange}
-      >
-        <option value="Location">Location</option>
-      </select>
-    </div>
-  );
+  const setFilters = (filter) => {
+    const uniqueFilters = events.reduce((acc, event) => {
+      if (!acc.includes(event.attributes[filter])) {
+        acc.push(event.attributes[filter])
+      }
+      return acc
+    }, []);
+    return uniqueFilters.map(item => {
+      const formattedItem = filter === 'event_type' ? formatType(item) : item;
+      return (<option value={`${item}`}>{formattedItem}</option>)
+    })
+  }
+
+  const setMonthFilter = () => {
+    const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+    return months.map((month, index) => {
+      const matchingEvents = events.filter(event => {
+        const eventMonth = event.attributes.start_date.split('-')[0];
+        return parseInt(eventMonth) === index + 1
+      })
+    return (<option value={`${month}`}>{month} ({matchingEvents.length})</option>)
+    })
+  }
+
+  const formatType = (item) => {
+    let itemArr = item.split('');
+    itemArr[0] = itemArr[0].toUpperCase();
+    return itemArr.join('');
+  }
+
+  if (events.length) {
+    return (
+      <div className="Filters">
+        <h3 className="filters-title">FILTER EVENTS</h3>
+        <select
+          name="event_type"
+          value={eventType}
+          onChange={(e) => updateType(e.target.value)}
+        >
+          <option value="">Event Type</option>
+          {setFilters('event_type')}
+        </select>
+        <select
+          name="month"
+          value={month}
+          onChange={(e) => updateMonth(e.target.value)}
+        >
+          <option value="Month">Month</option>
+          {setMonthFilter()}
+        </select>
+        <select
+          name="state"
+          value={state}
+          onChange={(e) => updateState(e.target.value)}
+        >
+          <option value="State">State</option>
+          {setFilters('state')}
+        </select>
+      </div>
+    );
+  } else {
+    return(<div></div>)
+  }
 }
 
-export default Filters;
+export const mapStateToProps = (state) => ({
+  events: state.events,
+});
+
+export default connect(mapStateToProps)(Filters);

--- a/src/containers/Filters/Filters.js
+++ b/src/containers/Filters/Filters.js
@@ -16,7 +16,7 @@ export const Filters = ({ events }) => {
     }, []);
     return uniqueFilters.map(item => {
       const formattedItem = filter === 'event_type' ? formatType(item) : item;
-      return (<option value={`${item}`}>{formattedItem}</option>)
+      return (<option key={item} value={item}>{formattedItem}</option>)
     })
   }
 
@@ -27,7 +27,7 @@ export const Filters = ({ events }) => {
         const eventMonth = event.attributes.start_date.split('-')[0];
         return parseInt(eventMonth) === index + 1
       })
-    return (<option value={`${month}`}>{month} ({matchingEvents.length})</option>)
+      return (<option key={month} value={month}>{month} ({matchingEvents.length})</option>)
     })
   }
 
@@ -46,7 +46,7 @@ export const Filters = ({ events }) => {
           value={eventType}
           onChange={(e) => updateType(e.target.value)}
         >
-          <option value="">Event Type</option>
+          <option key='Type' value=''>Event Type</option>
           {setFilters('event_type')}
         </select>
         <select
@@ -54,7 +54,7 @@ export const Filters = ({ events }) => {
           value={month}
           onChange={(e) => updateMonth(e.target.value)}
         >
-          <option value="Month">Month</option>
+          <option key='Month' value=''>Month</option>
           {setMonthFilter()}
         </select>
         <select
@@ -62,7 +62,7 @@ export const Filters = ({ events }) => {
           value={state}
           onChange={(e) => updateState(e.target.value)}
         >
-          <option value="State">State</option>
+          <option key='State'value=''>State</option>
           {setFilters('state')}
         </select>
       </div>


### PR DESCRIPTION
Added functionality to set filters based on events in redux store

For filtering based on the FE vs. BE events, I keep going back and forth. Now that I've started working on this filter functionality, I think it will be better to use query params in the BE to update our redux store events each time we filter. 

This will dynamically update the option elements that are displayed in the drop downs so that the user is only filtering the remaining events. If we try filtering on the FE, I think it could get messy storing multiple different versions of "events".

Let me know your thoughts, thanks!